### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci_build_dotnet.yml
+++ b/.github/workflows/ci_build_dotnet.yml
@@ -2,6 +2,8 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-net
 
 name: CI Build
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/DarkFactorAS/DFCommonLib/security/code-scanning/2](https://github.com/DarkFactorAS/DFCommonLib/security/code-scanning/2)

To fix the problem, explicitly set the `permissions` key in the workflow file to restrict the `GITHUB_TOKEN` to the minimum required privileges. Since the workflow only needs to check out code and build/test (no deployment, no PR/issue manipulation), the minimal permission required is `contents: read`. This can be set at the workflow level (applies to all jobs) or at the job level. The best practice is to add it at the top level, just after the `name` field and before `on:`. No other changes are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
