### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy_nuget.yml
+++ b/.github/workflows/deploy_nuget.yml
@@ -2,6 +2,8 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-net
 
 name: Deploy NuGet package
+permissions:
+  contents: read
 
 env:
   PROJECT: DFCommonLib.csproj


### PR DESCRIPTION
Potential fix for [https://github.com/DarkFactorAS/DFCommonLib/security/code-scanning/1](https://github.com/DarkFactorAS/DFCommonLib/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow file to explicitly set the minimum required permissions for the `GITHUB_TOKEN`. Since the workflow only checks out code and pushes to a NuGet feed (using a secret token, not the `GITHUB_TOKEN`), it likely only needs `contents: read` permission. The best way to fix this is to add the following block at the top level of the workflow (after the `name` field and before `env`), which will apply to all jobs in the workflow:

```yaml
permissions:
  contents: read
```

No additional methods, imports, or definitions are needed. Only the YAML file needs to be edited.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
